### PR TITLE
Added LaTeX conceal symbols

### DIFF
--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -124,6 +124,7 @@ syntax include @LATEX syntax/tex.vim
 syntax region orgMath     start="\\begin\[.*\]{.*}"  end="\\end{.*}"         keepend contains=@LATEX
 syntax region orgMath     start="\\begin{.*}"        end="\\end{.*}"         keepend contains=@LATEX
 syntax region orgMath     start="\\\["               end="\\\]"              keepend contains=@LATEX
+syntax region orgMath     start="\\("                end="\\)"               keepend contains=@LATEX
 syntax region orgMath     start="\S\@<=\$\|\$\S\@="  end="\S\@<=\$\|\$\S\@=" keepend oneline contains=@LATEX
 syntax region orgMath     start=/\$\$/               end=/\$\$/              keepend contains=@LATEX
 syntax region orgMath     start=/\\\@<!\\\[/         end=/\\\@<!\\\]/        keepend contains=@LATEX

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -18,10 +18,10 @@ endif
 syntax spell toplevel
 
 " Bold, underine, italic, etc.
-syntax region orgItalic        matchgroup=orgItalicDelimiter        start="[^ \t\k]\@<!\/\k\@=\/\@!" end="\k\@<=\/\@<!\/" keepend contains=@Spell
-syntax region orgBold          matchgroup=orgBoldDelimiter          start="[^ \t\k]\@<!\*\k\@=\*\@!" end="\k\@<=\*\@<!\*" keepend contains=@Spell
-syntax region orgUnderline     matchgroup=orgUnderlineDelimiter     start="[^ \t\k]\@<!_\k\@=_\@!"   end="\k\@<=_\@<!_"   keepend contains=@Spell
-syntax region orgStrikethrough matchgroup=orgStrikethroughDelimiter start="[^ \t\k]\@<!+\k\@=+\@!"   end="\k\@<=+\@<!+"   keepend contains=@Spell
+syntax region orgItalic        matchgroup=orgItalicDelimiter        start="[^ \t\k]\@<!\/\k\@=\/\@!" end="\k\@<=\/\@<!\/" keepend oneline contains=@Spell
+syntax region orgBold          matchgroup=orgBoldDelimiter          start="[^ \t\k]\@<!\*\k\@=\*\@!" end="\k\@<=\*\@<!\*" keepend oneline contains=@Spell
+syntax region orgUnderline     matchgroup=orgUnderlineDelimiter     start="[^ \t\k]\@<!_\k\@=_\@!"   end="\k\@<=_\@<!_"   keepend oneline contains=@Spell
+syntax region orgStrikethrough matchgroup=orgStrikethroughDelimiter start="[^ \t\k]\@<!+\k\@=+\@!"   end="\k\@<=+\@<!+"   keepend oneline contains=@Spell
 
 if org#option('org_use_italics', 1)
     highlight def orgItalic term=italic cterm=italic gui=italic

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -121,7 +121,7 @@ highlight def link orgHyperRight Comment
 "   more info run :h tex-conceal.
 " Ref: https://orgmode.org/manual/LaTeX-fragments.html#LaTeX-fragments
 syntax include @LATEX syntax/tex.vim
-syntax region orgMath     start="\\begin[.*]{.*}"  end="\\end{.*}" 		 keepend contains=@LATEX
+syntax region orgMath     start="\\begin\[.*\]{.*}"  end="\\end{.*}" 		 keepend contains=@LATEX
 syntax region orgMath     start="\\begin{.*}" 	 end="\\end{.*}" 		 keepend contains=@LATEX
 syntax region orgMath     start="\\\[" 				 end="\\\]" 			 keepend contains=@LATEX
 syntax region orgMath     start="\S\@<=\$\|\$\S\@="   end="\S\@<=\$\|\$\S\@="  keepend oneline contains=@LATEX

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -18,10 +18,10 @@ endif
 syntax spell toplevel
 
 " Bold, underine, italic, etc.
-syntax region orgItalic        matchgroup=orgItalicDelimiter        start="[^ \t\k]\@<!\/\k\@=\/\@!" end="\k\@<=\/\@<!\/" keepend oneline contains=@Spell
-syntax region orgBold          matchgroup=orgBoldDelimiter          start="[^ \t\k]\@<!\*\k\@=\*\@!" end="\k\@<=\*\@<!\*" keepend oneline contains=@Spell
-syntax region orgUnderline     matchgroup=orgUnderlineDelimiter     start="[^ \t\k]\@<!_\k\@=_\@!"   end="\k\@<=_\@<!_"   keepend oneline contains=@Spell
-syntax region orgStrikethrough matchgroup=orgStrikethroughDelimiter start="[^ \t\k]\@<!+\k\@=+\@!"   end="\k\@<=+\@<!+"   keepend oneline contains=@Spell
+syntax region orgItalic        matchgroup=orgItalicDelimiter        start="[^ \t\k]\@<!\/\k\@=\/\@!" end="\k\@<=\/\@<!\/" keepend contains=@Spell
+syntax region orgBold          matchgroup=orgBoldDelimiter          start="[^ \t\k]\@<!\*\k\@=\*\@!" end="\k\@<=\*\@<!\*" keepend contains=@Spell
+syntax region orgUnderline     matchgroup=orgUnderlineDelimiter     start="[^ \t\k]\@<!_\k\@=_\@!"   end="\k\@<=_\@<!_"   keepend contains=@Spell
+syntax region orgStrikethrough matchgroup=orgStrikethroughDelimiter start="[^ \t\k]\@<!+\k\@=+\@!"   end="\k\@<=+\@<!+"   keepend contains=@Spell
 
 if org#option('org_use_italics', 1)
     highlight def orgItalic term=italic cterm=italic gui=italic

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -65,12 +65,12 @@ highlight def link orgComment Comment
 
 
 " Headings
-syntax match orgHeading1 /^\s*\*\{1}\s\+.*$/ keepend contains=@Spell,orgTag,orgTodo
-syntax match orgHeading2 /^\s*\*\{2}\s\+.*$/ keepend contains=@Spell,orgTag,orgTodo
-syntax match orgHeading3 /^\s*\*\{3}\s\+.*$/ keepend contains=@Spell,orgTag,orgTodo
-syntax match orgHeading4 /^\s*\*\{4}\s\+.*$/ keepend contains=@Spell,orgTag,orgTodo
-syntax match orgHeading5 /^\s*\*\{5}\s\+.*$/ keepend contains=@Spell,orgTag,orgTodo
-syntax match orgHeading6 /^\s*\*\{6,}\s\+.*$/ keepend contains=@Spell,orgTag,orgTodo
+syntax match orgHeading1 /^\s*\*\{1}\s\+.*$/ keepend contains=@Spell,orgTag,orgTodo,orgMath
+syntax match orgHeading2 /^\s*\*\{2}\s\+.*$/ keepend contains=@Spell,orgTag,orgTodo,orgMath
+syntax match orgHeading3 /^\s*\*\{3}\s\+.*$/ keepend contains=@Spell,orgTag,orgTodo,orgMath
+syntax match orgHeading4 /^\s*\*\{4}\s\+.*$/ keepend contains=@Spell,orgTag,orgTodo,orgMath
+syntax match orgHeading5 /^\s*\*\{5}\s\+.*$/ keepend contains=@Spell,orgTag,orgTodo,orgMath
+syntax match orgHeading6 /^\s*\*\{6,}\s\+.*$/ keepend contains=@Spell,orgTag,orgTodo,orgMath
 
 syntax match orgTag /:\w\{-}:/ contained contains=orgTag
 exec 'syntax keyword orgTodo contained ' . join(org#option('org_state_keywords', ['TODO', 'NEXT', 'DONE']), ' ')
@@ -111,5 +111,22 @@ highlight def link orgHyperCentre Comment
 highlight def link orgHyperLeft Comment
 highlight def link orgHyperRight Comment
 
+" TeX
+" Support for both inline and block based embedded latex
+" eg: $Latex$ for inline or $$ LaTeX $$ for a block
+" Note:
+" - $LaTeX$ uses the tex.vim syntax for its conceal properties
+" - Inspired by https://github.com/vim-pandoc/vim-pandoc-syntax
+" - the conceal settings follows your g:tex_conceal setting for
+"   more info run :h tex-conceal.
+" Ref: https://orgmode.org/manual/LaTeX-fragments.html#LaTeX-fragments
+syntax include @LATEX syntax/tex.vim
+syntax region orgMath     start="\\begin[.*]{.*}"  end="\\end{.*}" 		 keepend contains=@LATEX
+syntax region orgMath     start="\\begin{.*}" 	 end="\\end{.*}" 		 keepend contains=@LATEX
+syntax region orgMath     start="\\\[" 				 end="\\\]" 			 keepend contains=@LATEX
+syntax region orgMath     start="\S\@<=\$\|\$\S\@="   end="\S\@<=\$\|\$\S\@="  keepend oneline contains=@LATEX
+syntax region orgMath     start=/\$\$/                end=/\$\$/              keepend contains=@LATEX
+syntax region orgMath     start=/\\\@<!\\\[/          end=/\\\@<!\\\]/        keepend contains=@LATEX
+hi def link orgMath     String
 
 let b:current_syntax = 'org'

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -121,12 +121,12 @@ highlight def link orgHyperRight Comment
 "   more info run :h tex-conceal.
 " Ref: https://orgmode.org/manual/LaTeX-fragments.html#LaTeX-fragments
 syntax include @LATEX syntax/tex.vim
-syntax region orgMath     start="\\begin\[.*\]{.*}"  end="\\end{.*}" 		 keepend contains=@LATEX
-syntax region orgMath     start="\\begin{.*}" 	 end="\\end{.*}" 		 keepend contains=@LATEX
-syntax region orgMath     start="\\\[" 				 end="\\\]" 			 keepend contains=@LATEX
-syntax region orgMath     start="\S\@<=\$\|\$\S\@="   end="\S\@<=\$\|\$\S\@="  keepend oneline contains=@LATEX
-syntax region orgMath     start=/\$\$/                end=/\$\$/              keepend contains=@LATEX
-syntax region orgMath     start=/\\\@<!\\\[/          end=/\\\@<!\\\]/        keepend contains=@LATEX
+syntax region orgMath     start="\\begin\[.*\]{.*}"  end="\\end{.*}"         keepend contains=@LATEX
+syntax region orgMath     start="\\begin{.*}"        end="\\end{.*}"         keepend contains=@LATEX
+syntax region orgMath     start="\\\["               end="\\\]"              keepend contains=@LATEX
+syntax region orgMath     start="\S\@<=\$\|\$\S\@="  end="\S\@<=\$\|\$\S\@=" keepend oneline contains=@LATEX
+syntax region orgMath     start=/\$\$/               end=/\$\$/              keepend contains=@LATEX
+syntax region orgMath     start=/\\\@<!\\\[/         end=/\\\@<!\\\]/        keepend contains=@LATEX
 hi def link orgMath     String
 
 let b:current_syntax = 'org'

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -127,7 +127,6 @@ syntax region orgMath     start="\\\["               end="\\\]"              kee
 syntax region orgMath     start="\\("                end="\\)"               keepend contains=@LATEX
 syntax region orgMath     start="\S\@<=\$\|\$\S\@="  end="\S\@<=\$\|\$\S\@=" keepend oneline contains=@LATEX
 syntax region orgMath     start=/\$\$/               end=/\$\$/              keepend contains=@LATEX
-syntax region orgMath     start=/\\\@<!\\\[/         end=/\\\@<!\\\]/        keepend contains=@LATEX
 hi def link orgMath     String
 
 let b:current_syntax = 'org'

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -127,6 +127,7 @@ syntax region orgMath     start="\\\["               end="\\\]"              kee
 syntax region orgMath     start="\\("                end="\\)"               keepend contains=@LATEX
 syntax region orgMath     start="\S\@<=\$\|\$\S\@="  end="\S\@<=\$\|\$\S\@=" keepend oneline contains=@LATEX
 syntax region orgMath     start=/\$\$/               end=/\$\$/              keepend contains=@LATEX
+syntax match  orgMath /\\\$/ conceal cchar=$
 hi def link orgMath     String
 
 let b:current_syntax = 'org'


### PR DESCRIPTION
Adds the ability to use vim's native tex syntax inside a latex codeblock.

AKA

this
![2020-03-27_19:28:38](https://user-images.githubusercontent.com/34443260/77811673-90b2d880-7061-11ea-9aaf-926ffd19a6f5.png)

becomes this
![2020-03-27_19:29:15](https://user-images.githubusercontent.com/34443260/77811652-74af3700-7061-11ea-9f28-322b90b8c55b.png)

