### PR TITLE
Add /doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 samples/
+/doc/tags


### PR DESCRIPTION
This hides it from git status when org.vim is installed directly under ~/.vim using git clone.